### PR TITLE
UserLabTest: Value property type should be `double` instead `int`

### DIFF
--- a/src/Core/Entities/UserLabTest.cs
+++ b/src/Core/Entities/UserLabTest.cs
@@ -16,7 +16,7 @@ namespace HealthPanel.Core.Entities
         [Required] 
         public int UserId { get; set; }
         public DateTime Date { get; set; }
-        public int Value { get; set; }
+        public double Value { get; set; }
         public TestStatus Status { get; set; }
     }
 }

--- a/src/Infrastructure/Migrations/20220215193814_EntityUserLabTestPropertyValueEditedToDouble.Designer.cs
+++ b/src/Infrastructure/Migrations/20220215193814_EntityUserLabTestPropertyValueEditedToDouble.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HealthPanel.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace HealthPanel.Infrastructure.Migrations
 {
     [DbContext(typeof(HealthPanelDbContext))]
-    partial class HealthPanelDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220215193814_EntityUserLabTestPropertyValueEditedToDouble")]
+    partial class EntityUserLabTestPropertyValueEditedToDouble
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20220215193814_EntityUserLabTestPropertyValueEditedToDouble.cs
+++ b/src/Infrastructure/Migrations/20220215193814_EntityUserLabTestPropertyValueEditedToDouble.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HealthPanel.Infrastructure.Migrations
+{
+    public partial class EntityUserLabTestPropertyValueEditedToDouble : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<double>(
+                name: "value",
+                table: "user_lab_tests",
+                type: "double precision",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "value",
+                table: "user_lab_tests",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(double),
+                oldType: "double precision");
+        }
+    }
+}

--- a/src/Services/Stats/Dtos/UserLabTestDto.cs
+++ b/src/Services/Stats/Dtos/UserLabTestDto.cs
@@ -9,7 +9,7 @@ namespace HealthPanel.Services.Stats.Dtos
         public int LabTestId { get; set; } 
         public int UserId { get; set; }
         public DateTime Date { get; set; }
-        public int Value { get; set; }
+        public double Value { get; set; }
         public string Status { get; set; } 
         
         public LabTestDto Test {get; set;}


### PR DESCRIPTION
- [x] UserLabTest entity: edit Value property type to double
- [ ] UserLabTest dto: edit Value property type to double
- [x] Migration